### PR TITLE
Allow specifying tag order for API groups in Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ func main() {
             "description": "A simple CRUD example using Go and PostgreSQL",
             "version":     "1.0.0",
         },
+        // The order of Tags above will be reflected in the Swagger UI
+        // allowing you to prioritize groups such as Auth API first.
+        Tags: []string{"Auth API", "Example API"},
     })
 
     rg := r.Group("/api")
@@ -90,6 +93,7 @@ func main() {
             {
                 Method: tonic.Get,
                 Url: "/ping",
+                Tags: []string{"Example API"},
                 HandlerRegister: func(path string) {
                     rg.GET(path, Ping)
                 },

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	OpenAPIVersion string         `json:"openapi"`
 	Info           map[string]any `json:"info"`
 	ExternalDocs   *ExternalDocs  `json:"externalDocs,omitempty"`
+	Tags           []string       `json:"tags,omitempty"`
 }
 
 var isInit = false
@@ -29,6 +30,13 @@ func Init(config *Config) {
 	}
 	if config.ExternalDocs != nil {
 		apiSpec["externalDocs"] = config.ExternalDocs
+	}
+	if len(config.Tags) > 0 {
+		tagObjs := make([]map[string]any, len(config.Tags))
+		for i, t := range config.Tags {
+			tagObjs[i] = map[string]any{"name": t}
+		}
+		apiSpec["tags"] = tagObjs
 	}
 	apiSpec["components"] = map[string]any{
 		"schemas": make(map[string]any),


### PR DESCRIPTION
This PR adds support for specifying the order of API tags in the OpenAPI spec, so they appear in the desired order in Swagger UI.