### PR TITLE
feat: support multiple OpenAPI UI renderers and fix multi-source bind validation

### DIFF
--- a/adapters/echo/http.go
+++ b/adapters/echo/http.go
@@ -10,11 +10,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func UIHandle(e *echo.Echo, spec *docs.OpenApi, path string) {
-	New(spec).UIHandle(e, path)
+func UIHandle(e *echo.Echo, spec *docs.OpenApi, path string, ui ...core.UI) {
+	New(spec).UIHandle(e, path, ui...)
 }
 
-func (a *Adapter) UIHandle(e *echo.Echo, path string) {
+func (a *Adapter) UIHandle(e *echo.Echo, path string, ui ...core.UI) {
 	spec := a.spec
 	if strings.HasSuffix(path, "/") {
 		path = path[:len(path)-1]
@@ -23,7 +23,11 @@ func (a *Adapter) UIHandle(e *echo.Echo, path string) {
 			return c.Redirect(http.StatusMovedPermanently, fmt.Sprintf("%s/index.html", path))
 		})
 	}
+	selected := core.SwaggerUI
+	if len(ui) > 0 {
+		selected = ui[0]
+	}
 	swaggerPath := fmt.Sprintf("%s.json", path)
 	e.GET(swaggerPath, echo.WrapHandler(core.JsonHttpHandler(spec)))
-	e.GET(fmt.Sprintf("%s/*", path), echo.WrapHandler(core.SwaggerUIHandler(swaggerPath)))
+	e.GET(fmt.Sprintf("%s/*", path), echo.WrapHandler(core.UIHandler(selected, swaggerPath)))
 }

--- a/adapters/gin/http.go
+++ b/adapters/gin/http.go
@@ -10,18 +10,22 @@ import (
 	"github.com/TickLabVN/tonic/core/docs"
 )
 
-func UIHandle(e *gin.Engine, spec *docs.OpenApi, path string) {
-	New(spec).UIHandle(e, path)
+func UIHandle(e *gin.Engine, spec *docs.OpenApi, path string, ui ...core.UI) {
+	New(spec).UIHandle(e, path, ui...)
 }
 
-func (a *Adapter) UIHandle(e *gin.Engine, path string) {
+func (a *Adapter) UIHandle(e *gin.Engine, path string, ui ...core.UI) {
 	if strings.HasSuffix(path, "/") {
 		path = path[:len(path)-1]
 	} else {
 		e.GET(path, func(c *gin.Context) { c.Redirect(http.StatusMovedPermanently, fmt.Sprintf("%s/index.html", path)) })
 	}
+	selected := core.SwaggerUI
+	if len(ui) > 0 {
+		selected = ui[0]
+	}
 	swaggerPath := fmt.Sprintf("%s.json", path)
 	spec := a.spec
 	e.GET(swaggerPath, gin.WrapH(core.JsonHttpHandler(spec)))
-	e.GET(fmt.Sprintf("%s/*subpaths", path), gin.WrapH(core.SwaggerUIHandler(swaggerPath)))
+	e.GET(fmt.Sprintf("%s/*subpaths", path), gin.WrapH(core.UIHandler(selected, swaggerPath)))
 }

--- a/core/http.go
+++ b/core/http.go
@@ -2,9 +2,7 @@ package core
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/TickLabVN/tonic/core/docs"
 )
@@ -15,43 +13,3 @@ func JsonHttpHandler(spec *docs.OpenApi) http.Handler {
 		json.NewEncoder(w).Encode(spec)
 	})
 }
-
-func SwaggerUIHandler(url string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = fmt.Fprintf(w, swaggerUIHTML, strconv.Quote(url))
-	})
-}
-
-const swaggerUIHTML = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tonic API Docs</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css">
-  <style>
-    html { box-sizing: border-box; overflow-y: scroll; }
-    *, *:before, *:after { box-sizing: inherit; }
-    body { margin: 0; background: #fafafa; }
-  </style>
-</head>
-<body>
-  <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-bundle.js" crossorigin></script>
-  <script src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-standalone-preset.js" crossorigin></script>
-  <script>
-    window.ui = SwaggerUIBundle({
-      url: %s,
-      dom_id: '#swagger-ui',
-      deepLinking: true,
-      presets: [
-        SwaggerUIBundle.presets.apis,
-        SwaggerUIStandalonePreset
-      ],
-      layout: "StandaloneLayout"
-    });
-  </script>
-</body>
-</html>
-`

--- a/core/ui.go
+++ b/core/ui.go
@@ -1,0 +1,123 @@
+package core
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"strconv"
+)
+
+type UI string
+
+const (
+	SwaggerUI UI = "swagger" // default
+	ReDoc     UI = "redoc"
+	Scalar    UI = "scalar"
+	RapiDoc   UI = "rapidoc"
+)
+
+var uiRenderers = map[UI]func(url string) string{
+	SwaggerUI: func(url string) string { return fmt.Sprintf(swaggerUIHTML, strconv.Quote(url)) },
+	ReDoc:     func(url string) string { return fmt.Sprintf(redocHTML, html.EscapeString(url)) },
+	Scalar:    func(url string) string { return fmt.Sprintf(scalarHTML, html.EscapeString(url)) },
+	RapiDoc:   func(url string) string { return fmt.Sprintf(rapidocHTML, html.EscapeString(url)) },
+}
+
+func UIHandler(ui UI, url string) http.Handler {
+	render, ok := uiRenderers[ui]
+	if !ok {
+		render = uiRenderers[SwaggerUI]
+	}
+	body := render(url)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+const swaggerUIHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tonic API Docs</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css">
+  <style>
+    html { box-sizing: border-box; overflow-y: scroll; }
+    *, *:before, *:after { box-sizing: inherit; }
+    body { margin: 0; background: #fafafa; }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-bundle.js" crossorigin></script>
+  <script src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-standalone-preset.js" crossorigin></script>
+  <script>
+    window.ui = SwaggerUIBundle({
+      url: %s,
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      layout: "StandaloneLayout"
+    });
+  </script>
+</body>
+</html>
+`
+
+const redocHTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Tonic API Docs</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='%s'></redoc>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>
+`
+
+const scalarHTML = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Tonic API Docs</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="app"></div>
+	<!-- Initialize the API Reference -->
+    <script id="api-reference" data-url="%s"></script>
+    <!-- Load the Script -->
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>`
+
+const rapidocHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tonic API Docs</title>
+  <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+</head>
+<body>
+  <rapi-doc spec-url="%s" theme="light"></rapi-doc>
+</body>
+</html>
+`

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -177,6 +177,8 @@ func main() {
 			Tags:        []string{"Orders"},
 		},
 	)
+	// Default renderer is Swagger UI. Pass a core.UI to pick another, e.g.:
+	// schema.UIHandle(e, "/docs", core.Redoc)   // or core.Scalar, core.RapiDoc
 	schema.UIHandle(e, "/docs")
 
 	e.Logger.Fatal(e.Start(":1323"))

--- a/examples/gin/main.go
+++ b/examples/gin/main.go
@@ -140,7 +140,7 @@ func main() {
 		OpenAPI: docs.VERSION,
 		Info: docs.InfoObject{
 			Version: "1.0.0",
-			Title:   "Echo Example API",
+			Title:   "Gin Example API",
 			Contact: &docs.ContactObject{
 				Name:  "Author",
 				URL:   "https://github.com/phucvinh57",

--- a/examples/gin/main.go
+++ b/examples/gin/main.go
@@ -174,6 +174,8 @@ func main() {
 			Description: "Shows filtered collections with pagination and regional headers.",
 			Tags:        []string{"Orders"},
 		}))
+	// Default renderer is Swagger UI. Pass a core.UI to pick another, e.g.:
+	// schema.UIHandle(g, "/docs", core.Redoc)   // or core.Scalar, core.RapiDoc
 	schema.UIHandle(g, "/docs")
 
 	g.Run(":1234")

--- a/examples/gin/middlewares/bindAll.go
+++ b/examples/gin/middlewares/bindAll.go
@@ -4,7 +4,17 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/go-playground/validator/v10"
 )
+
+var validate = validator.New(validator.WithRequiredStructEnabled())
+
+func init() {
+	validate.SetTagName("binding")
+	// Disable Gin's default validation since we're doing it manually after binding all sources
+	binding.Validator = nil
+}
 
 func Bind[T any](c *gin.Context) {
 	var req T
@@ -32,6 +42,11 @@ func Bind[T any](c *gin.Context) {
 				return
 			}
 		}
+	}
+	// Validate once, after every source has been bound
+	if err := validate.Struct(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "validation failed", "detail": err.Error()})
+		return
 	}
 	c.Set("data", req)
 	c.Next()


### PR DESCRIPTION
# Description

This PR adds the ability to choose between different OpenAPI documentation UI renderers, and fixes a validation bug in the Gin example's bind middleware where required fields from later binding sources (e.g. headers) were validated too early.
- Add UI renderer selection for the OpenAPI docs endpoint - supports Swagger UI (default), Redoc, Scalar, and RapiDoc via `UIHandle`.
- Fix request validation in the Gin example's `Bind` middleware: disable Gin's per-bind validator and validate the struct once after all sources (uri, query, header, body) are bound.
- Update the Gin example API title.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup / refactor
- [ ] 📚 Documentation update
- [ ] ⚙️ Other (please specify):