### PR TITLE
fix: handle edge cases in schema type parsing

### DIFF
--- a/core/docs/schema_object.go
+++ b/core/docs/schema_object.go
@@ -134,6 +134,10 @@ func SchemaFromType(t reflect.Type, parsingKey string, validateKey string, flag 
 		t = t.Elem()
 	}
 
+	if t.Kind() == reflect.Interface {
+		return SchemaObject{}, nil
+	}
+
 	schema := SchemaObject{}
 	var err error
 	schema.Type, err = toSwaggerType(t)
@@ -380,7 +384,11 @@ func SchemaFromType(t reflect.Type, parsingKey string, validateKey string, flag 
 			}
 
 			validateTag := field.Tag.Get(validateKey)
-			parsingAttr := strings.Split(field.Tag.Get(parsingKey), ",")
+			rawTag := field.Tag.Get(parsingKey)
+			if rawTag == "-" {
+				continue
+			}
+			parsingAttr := strings.Split(rawTag, ",")
 			var fieldName string
 			if len(parsingAttr) == 0 || parsingAttr[0] == "" {
 				continue // Skip if no parsing attributes are provided
@@ -438,7 +446,7 @@ func toSwaggerType(t reflect.Type) (string, error) {
 		return "array", nil
 	case reflect.Map:
 		return "map", nil
-	case reflect.Struct, reflect.Interface:
+	case reflect.Struct:
 		return "object", nil
 	case reflect.Pointer:
 		return toSwaggerType(t.Elem())


### PR DESCRIPTION
# Description

Fixes two correctness bugs in SchemaFromType (core/docs/schema_object.go):
- `json: "-"` fields were leaking into the schema as a property named "-" instead of being hidden. Now correctly skipped.
- `interface{}` / `any` fields (e.g. `map[string]any`, `[]any`) caused a panic. Now emit an empty schema {} (= any value).

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup / refactor
- [ ] 📚 Documentation update
- [ ] ⚙️ Other (please specify): 